### PR TITLE
Use a more efficient idiom for flattening nested lists

### DIFF
--- a/nltk/corpus/reader/api.py
+++ b/nltk/corpus/reader/api.py
@@ -14,6 +14,7 @@ from __future__ import unicode_literals
 import os
 import re
 from collections import defaultdict
+from itertools import chain
 
 from nltk import compat
 from nltk.data import PathPointer, FileSystemPathPointer, ZipFilePathPointer
@@ -426,10 +427,10 @@ class SyntaxCorpusReader(CorpusReader):
     #{ Block Readers
 
     def _read_word_block(self, stream):
-        return sum(self._read_sent_block(stream), [])
+        return list(chain(*self._read_sent_block(stream)))
 
     def _read_tagged_word_block(self, stream, tagset=None):
-        return sum(self._read_tagged_sent_block(stream, tagset), [])
+        return list(chain(*self._read_tagged_sent_block(stream, tagset)))
 
     def _read_sent_block(self, stream):
         return list(filter(None, [self._word(t) for t in self._read_block(stream)]))

--- a/nltk/parse/projectivedependencyparser.py
+++ b/nltk/parse/projectivedependencyparser.py
@@ -9,6 +9,7 @@
 from __future__ import print_function, unicode_literals
 
 from collections import defaultdict
+from itertools import chain
 
 from nltk.grammar import (DependencyProduction, DependencyGrammar,
                           ProbabilisticDependencyGrammar)
@@ -367,8 +368,7 @@ class ProbabilisticProjectiveDependencyParser(object):
         for dg in graphs:
             for node_index in range(1, len(dg.nodes)):
                 #children = dg.nodes[node_index]['deps']
-                # Put list so that in will work in python 3
-                children = sum(list(dg.nodes[node_index]['deps'].values()), [])
+                children = list(chain(*dg.nodes[node_index]['deps'].values()))
                 
                 nr_left_children = dg.left_children(node_index)
                 nr_right_children = dg.right_children(node_index)
@@ -428,7 +428,7 @@ class ProbabilisticProjectiveDependencyParser(object):
         prob = 1.0
         for node_index in range(1, len(dg.nodes)):
             #children = dg.nodes[node_index]['deps']
-            children = sum(list(dg.nodes[node_index]['deps'].values()), [])
+            children = list(chain(*dg.nodes[node_index]['deps'].values()))
             
             nr_left_children = dg.left_children(node_index)
             nr_right_children = dg.right_children(node_index)

--- a/nltk/sem/drt.py
+++ b/nltk/sem/drt.py
@@ -9,6 +9,7 @@ from __future__ import print_function, unicode_literals
 
 import operator
 from functools import reduce
+from itertools import chain
 
 from nltk.compat import string_types, python_2_unicode_compatible
 from nltk.sem.logic import (APP, AbstractVariableExpression, AllExpression,
@@ -339,7 +340,7 @@ class DRS(DrtExpression, Expression):
     def get_refs(self, recursive=False):
         """:see: AbstractExpression.get_refs()"""
         if recursive:
-            conds_refs = self.refs + sum((c.get_refs(True) for c in self.conds), [])
+            conds_refs = self.refs + list(chain(*(c.get_refs(True) for c in self.conds)))
             if self.consequent:
                 conds_refs.extend(self.consequent.get_refs(True))
             return conds_refs

--- a/nltk/sem/glue.py
+++ b/nltk/sem/glue.py
@@ -8,6 +8,7 @@
 from __future__ import print_function, division, unicode_literals
 
 import os
+from itertools import chain
 
 import nltk
 from nltk.internals import Counter
@@ -235,13 +236,13 @@ class GlueDict(dict):
         if node is None:
             # TODO: should it be depgraph.root? Is this code tested?
             top = depgraph.nodes[0]
-            depList = sum(list(top['deps'].values()), [])
+            depList = list(chain(*top['deps'].values()))
             root = depgraph.nodes[depList[0]]
 
             return self.to_glueformula_list(depgraph, root, Counter(), verbose)
 
         glueformulas = self.lookup(node, depgraph, counter)
-        for dep_idx in sum(list(node['deps'].values()), []):
+        for dep_idx in chain(*node['deps'].values()):
             dep = depgraph.nodes[dep_idx]
             glueformulas.extend(self.to_glueformula_list(depgraph, dep, counter, verbose))
         return glueformulas
@@ -285,7 +286,7 @@ class GlueDict(dict):
     def _lookup_semtype_option(self, semtype, node, depgraph):
         relationships = frozenset(
             depgraph.nodes[dep]['rel'].lower()
-            for dep in sum(list(node['deps'].values()), [])
+            for dep in chain(*node['deps'].values())
             if depgraph.nodes[dep]['rel'].lower() not in OPTIONAL_RELATIONSHIPS
         )
 
@@ -418,7 +419,7 @@ class GlueDict(dict):
         """
         deps = [
             depgraph.nodes[dep]
-            for dep in sum(list(node['deps'].values()), [])
+            for dep in chain(*node['deps'].values())
             if depgraph.nodes[dep]['rel'].lower() == rel.lower()
         ]
 

--- a/nltk/sem/lfg.py
+++ b/nltk/sem/lfg.py
@@ -7,6 +7,8 @@
 # For license information, see LICENSE.TXT
 from __future__ import print_function, division, unicode_literals
 
+from itertools import chain
+
 from nltk.internals import Counter
 from nltk.compat import python_2_unicode_compatible
 
@@ -117,7 +119,7 @@ class FStructure(dict):
             if not fstruct.pred:
                 fstruct.pred = (word, tag)
 
-            children = [depgraph.nodes[idx] for idx in sum(list(node['deps'].values()), [])]
+            children = [depgraph.nodes[idx] for idx in chain(*node['deps'].values())]
             for child in children:
                 fstruct.safeappend(child['rel'], FStructure._read_depgraph(child, depgraph, label_counter, fstruct))
 

--- a/nltk/tag/api.py
+++ b/nltk/tag/api.py
@@ -10,6 +10,8 @@
 Interface for tagging each token in a sentence with supplementary
 information, such as its part of speech.
 """
+from itertools import chain
+
 from nltk.internals import overridden
 from nltk.metrics import accuracy
 
@@ -62,8 +64,8 @@ class TaggerI(object):
         """
 
         tagged_sents = self.tag_sents(untag(sent) for sent in gold)
-        gold_tokens = sum(gold, [])
-        test_tokens = sum(tagged_sents, [])
+        gold_tokens = list(chain(*gold))
+        test_tokens = list(chain(*tagged_sents))
         return accuracy(gold_tokens, test_tokens)
 
     def _check_params(self, train, model):


### PR DESCRIPTION
A few spots (most notably `TaggerI.evaluate`) use this idiom for flattening nested lists:

```
sum(L, [])
```

I've replaced that with:

```
list(chain(*L))
```

which is more transparent (I think) and much faster.
